### PR TITLE
Add simple parser and wizard to create custom prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Just execute `setup.sh` and keep an eye on what happens :crystal_ball:
 | -h, --help            | Print the option list.                                                |
 | -B, --bundles         | Set up bundles only.                                                  |
 | -b, --bundle _BUNDLE_ | Install just one particular bundle.                                   |
+| -p, --prompt          | Runs the prompt parser wizard (creates a prompt a-la-carte).          |
 | --no-updates          | Skip `apt-get update`. Not recommended unless you've already updated. |
 | -v, --verbose         | Makes setup more verbose, mostly useful for debugging.                |
 
@@ -43,6 +44,7 @@ In case you want to use this fast without checking how it works, you may change 
   * [Packages lists](./common/settings.sh)
   * [Bundles](./bundles/), for more details see [the guide](./bundles/about-bundles.md)
   * `~/.bash_aliases.local` and `~/.bash_functions.local` will be sourced if they exist
+  * Edit the [prompt templates](./art/prompt/templates/), or create a style for an existing one (it's as easy as changing values in a JSON file)
 
 ## Acknowledgements
   * **Basharat Sialvi** for the [magnific tutorial](https://askubuntu.com/a/283909/198486) on setting up *powerline* everywhere.

--- a/art/prompt/.gitignore
+++ b/art/prompt/.gitignore
@@ -1,0 +1,2 @@
+bash_prompt
+

--- a/art/prompt/generate.py
+++ b/art/prompt/generate.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python
+import sys, re, json, codecs, collections, argparse
+
+
+fgbg_function_regex = re.compile(r'([fb]g)\((.+)\)')
+
+template = ''
+variables = {'options': {}}
+
+# Gets a keyword by dot notation (and prepares it if it's a color)
+def parse_keyword(obj, ref):
+    val = obj
+    for key in ref.split('.'):
+        try:
+            val = val[key]
+        except KeyError:
+            return None
+
+    if key[-3:] == '_fg':
+        return '\[\e[38;5;' + val + 'm\]'
+    elif key[-3:] == '_bg':
+        return '\[\e[48;5;' + val + 'm\]'
+    else:
+        return val
+
+def change_fgbg(color, target_ground):
+    if target_ground == 'bg':
+        target_ground = '48'
+    else: # fg
+        target_ground = '38'
+
+    return re.sub(r'(?<=\\e\[)[34]8(?=;)', target_ground, color)
+
+# Matches:
+# {{ variable.in.json }}
+def process_variable_match(match):
+    keyword = match.group(1)
+
+    needs_inverting = re.match(fgbg_function_regex, keyword)
+    if needs_inverting:
+        keyword = needs_inverting.group(2)
+
+    replacement = parse_keyword(variables, keyword)
+    if replacement:
+        if needs_inverting:
+            return change_fgbg(replacement, needs_inverting.group(1))
+        else:
+            return replacement
+    elif replacement is None:
+        print('WARNING: Keyword <' + keyword + '> not found')
+        return ''
+
+# Matches:
+# {~ option ~} thing to be toggled {~ /option ~}
+def process_option_match(match):
+    if parse_keyword(variables['options'], match.group(1)) == 'yes':
+        return match.group(2)
+    else:
+        return ''
+
+# https://stackoverflow.com/a/3233356/854076
+def update_style(d, u):
+    for k, v in u.iteritems():
+        if isinstance(v, collections.Mapping):
+            r = update_style(d.get(k, {}), v)
+            d[k] = r
+        else:
+            d[k] = u[k]
+    return d
+
+def main():
+    global variables
+
+    args_parser = argparse.ArgumentParser(description='Parses a Bash prompt from a template using variables')
+    args_parser.add_argument('--template', '-t', nargs='?', default='fancy', help='Template name')
+    args_parser.add_argument('--style', '-s', nargs='?', default='default', help='Variation of the default style')
+    args_parser.add_argument('--hostname', '-w', nargs='?', default='', help='Override hostname with given value')
+    args = args_parser.parse_args()
+
+    template_path = 'templates/' + args.template + '/' + args.template + '.template'
+    try:
+        template = open(template_path, 'r').read().decode('utf-8')
+    except IOError:
+        print ('Template <' + args.template + '> not found')
+        exit(1)
+
+    variables_path = 'templates/' + args.template + '/styles/' + 'default.json'
+    variables = json.loads(open(variables_path, 'r').read().decode('utf-8'))
+
+    # Alt style besides 'default'
+    if args.style != 'default':
+        style_path = 'templates/' + args.template + '/styles/' + args.style + '.json'
+        try:
+            style = json.loads(open(style_path, 'r').read().decode('utf-8'))
+        except IOError:
+            print ('Style <'+ args.style + '> not found')
+            exit(1)
+        # Applies style on top of defaults
+        update_style(variables, style)
+
+    # Override hostname if defined
+    if len(args.hostname) > 0:
+        variables['strings']['hostname'] = args.hostname
+
+    result = re.sub(r"\{\{\s?(.+?)\s?\}\}", process_variable_match, template)
+    result = re.sub(r"\{~\s?(.+?)\s?~\}(.*?)\{~\s?/\1\s?~\}", process_option_match, result, flags=re.DOTALL)
+
+    the_output = codecs.open('bash_prompt', 'w', encoding='utf8')
+    the_output.write(result)
+
+main()

--- a/art/prompt/templates/fancy/fancy.template
+++ b/art/prompt/templates/fancy/fancy.template
@@ -1,13 +1,7 @@
 #!/bin/bash
 
-# Dear future me or whoever is wishing to modify the prompt:
-#
-# I'm so, so sorry. For a blisful moment I looked at escaped codes for colors
-# and actually *saw* the colors, as if the script were licking my eyeballs with
-# a sparkling rainbow and drowning me in a bucket full of joy.
-
 completely_dynamic_prompt() {
-    # Set terminal title to cwd, including hostname when connected via SSH
+    # Set terminal title to cwd, including hostname in caps when connected via SSH
     if [ -n "$SSH_CONNECTION" ] && [ -n "$HOSTNAME" ]; then
         PS1="\[\033]0;${HOSTNAME^^}: \w\007\]"
     else
@@ -15,23 +9,23 @@ completely_dynamic_prompt() {
     fi
 
     # Reset, set username background color
-    PS1+="\[\e[0m\]\[\e[48;5;237m\]"
-    # Set username color, which will later be overriden if no SSH connection
-    PS1+="\[\e[38;5;256m\]"
+    PS1+="\[\e[0m\]{{ colors.user_bg }}"
+    # Set username color for SSH connctions, overriden later if local
+    PS1+="{{ colors.ssh_user_fg }}"
     # Show user icon only if not going through a SSH connection
     # because I don't want my prompt to be an emoji parade
-    [ -z "$SSH_CONNECTION" ] && PS1+="\[\e[38;5;240m\]  \[\e[38;5;244m\]"
+    [ -z "$SSH_CONNECTION" ] && PS1+="{{ colors.user_symbol_fg }} {{ symbol.user }} {{ colors.user_fg }}"
     # Print username
-    PS1+="\u "
+    PS1+="{{ strings.username }} "
     # Show hostname only when connected through SSH
-    if [ -n "$SSH_CONNECTION" ]; then
-        # Set color, print symbol, set bold, print hostname
-        PS1+="\[\e[34m\] \[\e[1m\]\h "
-    fi
+    {~ hide_hostname_locally ~}if [ -n "$SSH_CONNECTION" ]; then{~ /hide_hostname_locally ~}
+        # Set color, print symbol
+        PS1+="{{ colors.hostname_symbol_fg }}{{ symbol.ssh }} "
+        # Set bold, print hostname
+        PS1+="\[\e[1m\]{{ colors.hostname_fg }}{{ strings.hostname }} "
+    {~ hide_hostname_locally ~}fi{~ /hide_hostname_locally ~}
     # Reset, set color, set background color for path, print closing section
-    PS1+="\[\e[0m\]\[\e[38;5;237m\]\[\e[48;5;234m\] "
-    # Set color
-    PS1+="\[\e[1;35m\]"
+    PS1+="\[\e[0m\]{{ fg(colors.user_bg) }}{{ colors.path_bg }} "
 
     ################
     # Path block ##
@@ -40,41 +34,41 @@ completely_dynamic_prompt() {
     # Want to change maximum path length? Do so here.
     # Try to set it somewhere around:
     #     columns - rest of the prompt length - 4
-    local max_path_length=48
+    local max_path_length={{ options.path_max_length }}
 
     # Initialize the path resetting bold
-    local path_magical_string='\[\e[21m\]'
+    local path_block_string='\[\e[21m\]'
 
     if [[ "$PWD" == "$HOME" ]]; then
         # We are home. Piece of cake. Print a nice little house and get out.
-        path_magical_string+='\[\e[38;5;166m\] '
+        path_block_string+='{{ colors.path_home_fg }}{{ symbol.home }} '
 
     elif [[ "$PWD" == "/tmp" ]]; then
         # Print a fancy trash can and call it a day.
-        path_magical_string+='\[\e[38;5;37m\] '
+        path_block_string+='{{ colors.path_tmp_fg }}{{ symbol.tmp }} '
 
     else # This isn't Kansas anymore
         # Elegant solution from here: https://superuser.com/a/443862/136571
         local the_dirname=${PWD%/*}/
         local the_cwd=${PWD##*/}
 
-        # Default purplish colors
-        local dirname_color='\[\e[38;5;96m\]'
-        local the_cwd_color='\[\e[38;5;132m\]'
+        # Default colors
+        local dirname_color='{{ colors.path_fg }}'
+        local the_cwd_color='{{ colors.path_cwd_fg }}'
 
         # Replace home path part with the nice little house™
         if [[ "$the_dirname" == "$HOME"* ]]; then
-            the_dirname=" ${the_dirname##*$HOME/}"
-            # Define orangish colors
-            #local dirname_color='\[\e[38;5;130m\]'
-            #local the_cwd_color='\[\e[38;5;166m\]'
+            the_dirname="{{ symbol.home }} ${the_dirname##*$HOME/}"
+            # Define homeish colors
+            #local dirname_color='{{ colors.path_home_fg }}'
+            #local the_cwd_color='{{ colors.path_home_fg }}'
 
         # Does the same for `/tmp` with a fancy trash can
         elif [[ "$the_dirname" == "/tmp/"* ]]; then
-            the_dirname=" ${the_dirname##*/tmp/}"
+            the_dirname="{{ symbol.tmp }} ${the_dirname##*/tmp/}"
             # Define cyanish colors
-            local dirname_color='\[\e[38;5;30m\]'
-            local the_cwd_color='\[\e[38;5;37m\]'
+            local dirname_color='{{ colors.path_tmp_fg }}'
+            local the_cwd_color='{{ colors.path_tmp_fg }}'
         fi
 
         # Used to get current path length
@@ -91,7 +85,7 @@ completely_dynamic_prompt() {
                 local tmp_prefix=''
 
                 # Save the nice little house™ for later if it is there
-                if [[ "$the_dirname" == " "* || "$the_dirname" == " "* ]]; then
+                if [[ "$the_dirname" == "{{ symbol.home }} "* || "$the_dirname" == "{{ symbol.tmp }} "* ]]; then
                     tmp_prefix=${the_dirname::2}
                     the_dirname=${the_dirname##*$tmp_prefix}
                 fi
@@ -136,9 +130,9 @@ completely_dynamic_prompt() {
 
 
         # Light color, print dirname
-        path_magical_string+="${dirname_color}$the_dirname"
+        path_block_string+="${dirname_color}$the_dirname"
         # Strong color, bold, print current directory, reset bold
-        path_magical_string+="${the_cwd_color}\[\e[1m\]$the_cwd\[\e[21m\] "
+        path_block_string+="${the_cwd_color}\[\e[1m\]$the_cwd\[\e[21m\] "
     fi
 
     ###############
@@ -152,14 +146,14 @@ completely_dynamic_prompt() {
           ("$(git rev-parse --is-inside-git-dir)" == "true") ]]; then
 
         # A cool arrow is returned
-        PS1+="${path_magical_string}\[\e[0m\]\[\e[38;5;234m\]\[\e[1;37m\]"
+        PS1+="${path_block_string}\[\e[0m\]{{ fg(colors.path_bg) }}{{ colors.arrow_fg }}{{ strings.prompt }}"
 
     else
 
         local modifiers='\[\e[21m\]' # Reset bold for crispier icons!
         local bgcolor=''
         local fgcolor='\[\e[38;5;0m\]' # Black
-        local icon=''
+        local icon='{{ symbol.git.branch }}'
 
         local top_level_path=$(git rev-parse --show-toplevel)
         local branchName="$( printf "$( git rev-parse --abbrev-ref HEAD 2> /dev/null \
@@ -171,17 +165,17 @@ completely_dynamic_prompt() {
 
             # Check for uncommitted changes in the index
             if ! $(git diff --quiet --ignore-submodules --cached); then
-              modifiers="$modifiers ";
+              modifiers="$modifiers {{ symbol.git.staged }}";
             fi
 
             # Check for unstaged changes
             if ! $(git diff-files --quiet --ignore-submodules --); then
-                modifiers="$modifiers ±";
+                modifiers="$modifiers {{ symbol.git.modified }}";
             fi
 
             # Check for untracked files
             if [ -n "$(git ls-files ${top_level_path} --others --exclude-standard)" ]; then
-                modifiers="$modifiers ";
+                modifiers="$modifiers {{ symbol.git.untracked }}";
             fi
 
         else # No changes
@@ -192,24 +186,25 @@ completely_dynamic_prompt() {
         git diff origin/${branchName}..${branchName} --quiet --exit-code 2>/dev/null
         case $? in
             1) # Branch has unpushed commits
-                modifiers=" $modifiers";
+                modifiers=" {{ symbol.git.unpushed }}$modifiers";
                 ;;
 
             128) # Error, asume we are in a new branch (not present in origin)
-                icon="";
+                icon="{{ symbol.git.new_branch }}";
                 ;;
         esac
 
 
         # Check if we are in the middle of a rebase
         if test -d "${top_level_path}/.git/rebase-merge" -o -d "${top_level_path}/.git/rebase-apply"; then
-            icon=''
+            icon='{{ symbol.git.rebase }}'
             bgcolor='\[\e[41m\]' # Red
             fgcolor='\[\e[97m\]' # White
         fi
 
         local bgcolor_for_fg=${bgcolor/[4/[3}
-        PS1+="${path_magical_string}${bgcolor}\[\e[38;5;234m\] ${fgcolor}${icon} ${branchName}${modifiers} \[\e[0m\]${bgcolor_for_fg}"
+        PS1+="${path_block_string}${bgcolor}{{ fg(colors.path_bg) }} "
+        PS1+="${fgcolor}${icon} ${branchName}${modifiers} \[\e[0m\]${bgcolor_for_fg}"
 
     fi
 
@@ -223,7 +218,7 @@ set_prompts() {
     export PROMPT_COMMAND='completely_dynamic_prompt'
 
     # This is what is shown when the interactive prompt appears in a new line
-    PS2='  '
+    PS2='{{ strings.custom_PS2 }}'
     export PS2
 
 

--- a/art/prompt/templates/fancy/styles/default.json
+++ b/art/prompt/templates/fancy/styles/default.json
@@ -1,0 +1,49 @@
+{
+    "options": {
+        "hide_hostname_locally": "yes",
+        "path_max_length": "48"
+    },
+
+    "strings": {
+        "username": "\\u",
+        "hostname": "\\h",
+        "custom_PS2": "  ",
+        "prompt": ""
+    },
+
+    "colors": {
+        "arrow_fg": "7",
+        "user_bg": "237",
+        "user_symbol_fg": "240",
+        "user_fg": "244",
+        "hostname_fg": "4",
+        "hostname_symbol_fg": "4",
+        "ssh_user_fg": "256",
+
+        "path_bg": "234",
+        "path_fg": "96",
+        "path_cwd_fg": "132",
+        "path_home_fg": "130",
+        "path_home_fg": "166",
+
+        "path_tmp_fg": "30",
+        "path_tmp_fg": "37"
+    },
+
+    "symbol": {
+        "user": "",
+        "ssh": "",
+        "home": "",
+        "tmp": "",
+
+        "git": {
+            "branch": "",
+            "staged": "",
+            "modified": "±",
+            "untracked": "",
+            "unpushed": "",
+            "new_branch": "",
+            "rebase": ""
+        }
+    }
+}

--- a/art/prompt/templates/fancy/styles/digital_ocean.json
+++ b/art/prompt/templates/fancy/styles/digital_ocean.json
@@ -1,0 +1,16 @@
+{
+    "options": {
+        "hide_hostname_locally": "yes"
+    },
+
+    "colors": {
+        "user_bg": "24",
+        "user_fg": "256",
+        "user_symbol_fg": "256",
+        "ssh_user_fg": "256"
+    },
+
+    "symbol": {
+        "ssh": ""
+    }
+}

--- a/art/prompt/templates/fancy/styles/work.json
+++ b/art/prompt/templates/fancy/styles/work.json
@@ -1,0 +1,27 @@
+{
+    "options": {
+        "hide_hostname_locally": "no"
+    },
+
+    "strings": {
+        "username": "\\u",
+        "hostname": "Work",
+        "prompt": ""
+    },
+
+    "colors": {
+        "arrow_fg": "157",
+        "user_bg": "235",
+        "hostname_fg": "34",
+        "hostname_symbol_fg": "22",
+
+        "path_bg": "237",
+        "path_fg": "96",
+        "path_cwd_fg": "132"
+    },
+
+    "symbol": {
+        "user": "",
+        "ssh": ""
+    }
+}

--- a/common/prompt-wizard.sh
+++ b/common/prompt-wizard.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+prompt_wizard() {
+    local generator_args=""
+    local templates=()
+    local styles=()
+
+    pushd "$(dirname "${BASH_SOURCE[0]}")/../art/prompt/templates/" &> /dev/null
+
+    # To avoid filling a description for each template item, here's a unicode space v
+    templates=($(ls -d */|sed 's#/##'|awk '{a[$1]=$1}END{for(i in a)printf " "a[i]"   on "}'))
+
+    # Show dialog only if more than one template
+    if [ ${#templates[@]} -gt 3 ]; then
+        exec 3>&1;
+        local selected_template=$(dialog --keep-tite --title "Templates" \
+            --radiolist "Pick a Bash prompt template" 16 32 10\
+            ${templates[@]} \
+            2>&1 1>&3 \
+        )
+        exec 3>&-
+
+        # Throw error if none selected
+        [ -z "${selected_template}" ] && return 1
+    else
+        # Use the only template available
+        selected_template=$(ls -d */|sed 's#/##')
+    fi
+    generator_args="${generator_args} --template=${selected_template}"
+
+    # Get into the template folder
+    if [ -d ${selected_template}/styles/ ]; then
+        pushd "${selected_template}/styles/" &> /dev/null
+
+        # To avoid filling a description for each style item, I used a unicode space here v too
+        styles=($(ls *.json|sed 's#.json##'|awk '{a[$1]=$1}END{for(i in a)printf " "a[i]"   on "}'))
+
+        # Take a moment to appreciate how I nailed the unicode space position in those two comments
+
+        # Show dialog only if more than one style
+        if [ ${#styles[@]} -gt 3 ]; then
+            exec 3>&1;
+            selected_style=$(dialog --keep-tite --title "Template style" \
+                --radiolist "Pick a style from this template's options" 16 40 10\
+                ${styles[@]} \
+                2>&1 1>&3 \
+            )
+            exec 3>&-
+
+            # Throw error if none selected
+            [ -z "${selected_style}" ] && return 1
+        else
+            # Use the only style available
+            selected_template=$(ls *.json|sed 's#.json##')
+        fi
+        generator_args="${generator_args} --style=${selected_style}"
+
+        # Out of template's styles folder
+        popd &>/dev/null
+    else
+        log WARN "No style folder found for template ${selected_template}"
+    fi
+
+    dialog --keep-tite --title "Customization" --yesno "Do you want to change the displayed hostname?" 6 39
+    if [ $? -eq 0 ]; then
+        exec 3>&1;
+        local custom_hostname=$(dialog --keep-tite --title "Customize displayed hostname" \
+                                --inputbox "Enter a custom hostname:" 8 36 2>&1 1>&3)
+        exec 3>&-
+    fi
+
+    if [ -n "${custom_hostname}" ]; then
+        generator_args="${generator_args} --hostname=${custom_hostname}"
+    fi
+
+    # Get into the generator's folder
+    pushd ".." &>/dev/null
+
+    python generate.py ${generator_args} &>/dev/null
+    if [ $? -eq 0 ] && [ -f bash_prompt ]; then
+        # Already exists -- back it up!
+        if [ -f "$HOME/.bash_prompt" ]; then
+            mv "$HOME/.bash_prompt" "../../backups/$(date +%Y%m%d-%H%M%S)-bash_prompt"
+            log NOTICE "Backed up previous .bash_prompt"
+        fi
+        mv bash_prompt "$HOME/.bash_prompt"
+    fi
+
+    # Out of generator folder
+    popd &>/dev/null
+
+    # Out of templates folder
+    popd &>/dev/null
+}

--- a/common/utils.sh
+++ b/common/utils.sh
@@ -37,8 +37,12 @@ clear_last_line() {
     tput cuu 1 && tput el
 }
 
-create_backup_folder() {
-    mkdir -p "$(dirname "${BASH_SOURCE[0]}")/../backups/"
+create_backup_directory() {
+    local backup_directory="$(dirname "${BASH_SOURCE[0]}")/../backups/"
+    if [ ! -d "${backup_directory}" ]; then
+        mkdir -p "${backup_directory}" && return 0
+    fi
+    return 1 # Already exists or error creating
 }
 
 function_exists() {

--- a/setup.sh
+++ b/setup.sh
@@ -167,24 +167,24 @@ main() {
 
     test_for "dialog" OR_ABORT
 
-    # Create a tarball of previous backup so ./backups folder is (almost) empty
-    local backup_postfix="dotfiles_backup.tar.gz"
-    local backup_files_count=$(ls -l -I "*${backup_postfix}" backups/|wc -l)
-    if [ ${backup_files_count} -gt 1 ]; then
-        pushd backups/ >/dev/null || exit 1 # Don't take any chances!
-        local backup_filename="$(date +%Y%m%d-%H%M%S)-${backup_postfix}"
-        tar -zcf ${backup_filename} --exclude="*${backup_postfix}" *
-        if [ $? ]; then
-            find . -mindepth 1 ! -name "*${backup_postfix}" -exec rm -rf {} +
-            log INFO "Backup files were stored in backups/${backup_filename}"
-        else
-            log ERROR "There was a problem creating a tarball of a previous backup"
-            exit 1
-        fi
-        popd >/dev/null
-    fi
-
     if [[ ! -v JUST_BUNDLES ]]; then
+        # Create a tarball of previous backup so ./backups folder is (almost) empty
+        local backup_postfix="dotfiles_backup.tar.gz"
+        local backup_files_count=$(ls -l -I "*${backup_postfix}" backups/|wc -l)
+        if [ ${backup_files_count} -gt 1 ]; then
+            pushd backups/ >/dev/null || exit 1 # Don't take any chances!
+            local backup_filename="$(date +%Y%m%d-%H%M%S)-${backup_postfix}"
+            tar -zcf ${backup_filename} --exclude="*${backup_postfix}" *
+            if [ $? ]; then
+                find . -mindepth 1 ! -name "*${backup_postfix}" -exec rm -rf {} +
+                log INFO "Backup files were stored in backups/${backup_filename}"
+            else
+                log ERROR "There was a problem creating a tarball of a previous backup"
+                exit 1
+            fi
+            popd >/dev/null
+        fi
+
         create_backup_folder
 
         test_for "stow" OR_WARN "Keep in mind bundles may need stow."

--- a/setup.sh
+++ b/setup.sh
@@ -167,6 +167,8 @@ main() {
 
     test_for "dialog" OR_ABORT
 
+    create_backup_directory && log INFO "Backup folder created"
+
     if [[ ! -v JUST_BUNDLES ]]; then
         # Create a tarball of previous backup so ./backups folder is (almost) empty
         local backup_postfix="dotfiles_backup.tar.gz"
@@ -184,8 +186,6 @@ main() {
             fi
             popd >/dev/null
         fi
-
-        create_backup_folder
 
         test_for "stow" OR_WARN "Keep in mind bundles may need stow."
         create_symlinks &&

--- a/setup.sh
+++ b/setup.sh
@@ -5,6 +5,7 @@ source 'common/utils.sh'
 source 'common/packages.sh'
 source 'common/bundles.sh'
 source 'common/logger.sh'
+source 'common/prompt-wizard.sh'
 
 # Default config for bashlog
 LOG_FILE=`readlink -f "$(dirname $0)/setup.log"`
@@ -32,6 +33,9 @@ OPTIONS
         --no-updates
            Skip `apt-get update`. Not recommended unless you already updated.
 
+        -p, --prompt
+           Shows the prompt parser wizard
+
         -v, --verbose
            Makes setup more verbose, mostly useful for debugging.
 
@@ -58,6 +62,7 @@ filter_args() {
 
         case $arg in
             -b|--bundle)
+                NO_UPDATES=1;
                 if [ -n "$2" ]; then
                     if bundle_exists $2; then
                         bundle_count=1
@@ -90,7 +95,10 @@ filter_args() {
             --no-updates)
                 NO_UPDATES=1;
                 ;;
-
+            -p|--prompt)
+                NO_UPDATES=1;
+                JUST_PROMPT=1;
+                ;;
             -v|-vv|-vvv|--verbose)
                 STDOUT_LOG_LEVEL="DEBUG"
                 log NOTICE "Verbosity set to ${STDOUT_LOG_LEVEL}."
@@ -114,6 +122,22 @@ init_git_submodules() {
     fi
     git submodule update &>/dev/null
     # It won't check if update succeeds because setup may be run offline
+}
+
+pick_prompt() {
+    if cmd_exists "python"; then
+        log INFO "Changing Bash prompt"
+        pretty_print INDENT RIGHT 3
+        prompt_wizard
+        if [ $? -eq 0 ]; then
+            log OK "Done"
+        else
+            log FAIL "Failed"
+        fi
+        pretty_print INDENT LEFT 3
+    else
+        log WARN "Skipping custom Bash prompt creation"
+    fi
 }
 
 print_splash() {
@@ -169,6 +193,12 @@ main() {
 
     create_backup_directory && log INFO "Backup folder created"
 
+    if [[ -v JUST_PROMPT ]]; then
+        test_for "python" OR_ABORT
+        pick_prompt
+        exit
+    fi
+
     if [[ ! -v JUST_BUNDLES ]]; then
         # Create a tarball of previous backup so ./backups folder is (almost) empty
         local backup_postfix="dotfiles_backup.tar.gz"
@@ -193,7 +223,10 @@ main() {
 
         set_keyboard_layout
 
+        test_for "python" OR_WARN "Python is needed to generate a custom Bash prompt."
+        pick_prompt
         #pick_motd
+
         pick_packages
     fi
 


### PR DESCRIPTION
This PR resolves #1 introducing a Python script that takes `{{ variables }}` from a JSON file, replaces occurrences in a template, and even allows 

```
{~ custom.conditions ~} to toggle content {~ /custom.conditions ~}
```

Furthermore, for a given template there may be more than one style (i.e. set of variables) that can be applied on top of the defaults (think of it like CSS).

To complete this tool (which can be used alone just by calling `generate.py` anyway) there's [a _wizard_](https://i.imgur.com/KraVTUS.gif) that runs as part of the setup process, or may be called specifically by running `setup.sh --prompt`. The wizard asks the user to select a template (if there's more than one), then a style (from those available for that template) and finally the string corresponding to the hostname can be customized (to identify computers with difficult hostnames more easily). Finally it copies the resulting `.bash_prompt` to the user's home directory, backing up the previous `.bash_prompt` if it exists.
